### PR TITLE
Remove django-jinja dependency

### DIFF
--- a/{{ cookiecutter.project_slug }}/core/settings.py
+++ b/{{ cookiecutter.project_slug }}/core/settings.py
@@ -45,7 +45,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "django_jinja",
     "core",
 ]
 
@@ -63,12 +62,6 @@ MIDDLEWARE = [
 ROOT_URLCONF = "core.urls"
 
 TEMPLATES = [
-    {
-        "BACKEND": "django_jinja.jinja2.Jinja2",
-        "DIRS": [],
-        "APP_DIRS": True,
-        "OPTIONS": {},
-    },
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [],

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -7,7 +7,6 @@ authors = [{name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.au
 requires-python = ">=3.11,<4.0"
 dependencies = [
 	"django >=5.1.2, <6.0.0",
-	"django-jinja >=2.11.0",
 	"whitenoise >=6.8.2",
 	"django-environ >=0.11.2",
 	"psycopg2 >=2.9.10",


### PR DESCRIPTION
## Summary
Removed django-jinja dependency in favor of Django's native template system.

## Changes
- 🗑️ Remove django-jinja from pyproject.toml dependencies
- 📝 Remove django_jinja from INSTALLED_APPS
- ⚙️ Update TEMPLATES configuration to use only Django's native backend
- 🧹 Clean up duplicate template backend configuration

## Benefits
- One less dependency to maintain
- Better IDE support and syntax highlighting for Django templates
- Simpler configuration
- Native Django template tags and filters

## Test plan
- [ ] Run the application and verify templates render correctly
- [ ] Check that all template tags work as expected
- [ ] Verify no Jinja2-specific syntax remains in templates

Note: This PR should be merged after PR #5 (Tailwind CSS frontend) as it depends on the template conversion from .jinja to .html files.

🤖 Generated with [Claude Code](https://claude.ai/code)